### PR TITLE
Enhance accessibility of <figure>

### DIFF
--- a/imgcaptions.php
+++ b/imgcaptions.php
@@ -51,7 +51,7 @@ class ImgCaptionsPlugin extends Plugin
 
                 /* Wrap <img> in <figure>, include class-attribute if set. */
                 $wrap = "/(<img(?:(\s*(class)\s*=\s*\x22([^\x22]+)\x22*)+|[^>]+?)*>)/";
-                $buffer = preg_replace($wrap, '<figure$2>$1</figure>', $buffer);
+                $buffer = preg_replace($wrap, '<figure role="group" $2>$1</figure>', $buffer);
 
                 /* If img-elements have a title set by Markdown, append them as <figcaption> them within <figure>. */
                 $title = "/<img[^>]*?title[ ]*=[ ]*[\"](.*?)[\"][^>]*?>/";


### PR DESCRIPTION
The `<figure>` element needs a "group" role on it to be correctly understood by screen readers.

Sources: 
* https://www.w3.org/WAI/tutorials/images/complex/ (en)
* http://www.accede-web.com/notices/html-css-javascript/6-images-icones/6-4-images-legendees-figure-rolegroup-figcaption/ (fr)
* http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-1-10 (fr)